### PR TITLE
Accessibility changes

### DIFF
--- a/js/adapt-expose.js
+++ b/js/adapt-expose.js
@@ -13,7 +13,7 @@ define(function(require) {
 			"click .expose-item-cover": "toggleItem",
 			"click .expose-item-content": "toggleItem",
 			"click .expose-item-button": "toggleItem",
-            "click .expose-item-button-screen-reader": "toggleItem"
+			"click .expose-item-button-screen-reader": "toggleItem"
 		},
 
 		onDeviceResize: function() {

--- a/js/adapt-expose.js
+++ b/js/adapt-expose.js
@@ -12,7 +12,8 @@ define(function(require) {
 		events: {
 			"click .expose-item-cover": "toggleItem",
 			"click .expose-item-content": "toggleItem",
-			"click .expose-item-button": "toggleItem"
+			"click .expose-item-button": "toggleItem",
+            "click .expose-item-button-screen-reader": "toggleItem"
 		},
 
 		onDeviceResize: function() {
@@ -73,6 +74,8 @@ define(function(require) {
 				var i = $cover.parents(".expose-item").index();
 				this.model.get("_items")[i]._isVisited = true;
 				this.evaluateCompletion();
+				// Add the content to the aria-live field, remove content's aria-hidden property
+				$parent.children(".expose-item-content-screen-reader").prepend($parent.children(".expose-item-content").clone().attr('aria-hidden', false));
 			}
 		},
 

--- a/less/expose.less
+++ b/less/expose.less
@@ -121,6 +121,15 @@
 			.zoom(0);
 		}
 	}
+
+	.screen-reader-only {
+		position:absolute;
+		left:-10000px;
+		top:auto;
+		width:1px;
+		height:1px;
+		overflow:hidden;
+	}
 }
 
 .expose-item-button {

--- a/templates/expose.hbs
+++ b/templates/expose.hbs
@@ -5,19 +5,21 @@
             {{#each _items}}
             <div class="expose-item nth-child-{{@index}}">
                 <div class="expose-item-inner">
-                    <button class="expose-item-button"></button>
+                    <button class="expose-item-button" aria-hidden="true"></button>
                     <div class="expose-item-cover">
                         <div class="back"></div>
                         <div class="front"></div>
                         <span class="text">{{#if front}} {{{a11y_text front}}} {{else}} ? {{/if}}</span>
                     </div>
-                    <div class="expose-item-content">
+                    <button class="screen-reader-only expose-item-button-screen-reader" aria-label="Expose button"></button>
+                    <div class="expose-item-content" aria-hidden="true">
                         {{#with back}}
                             {{#if title}}<div class="expose-item-title">{{{a11y_text title}}}</div>{{/if}}
                             {{#if body}}<div class="expose-item-body">{{{a11y_text body}}}</div>{{/if}}
                             {{#if _graphic}}<img class="expose-item-img" src="{{_graphic.src}}" alt="{{_graphic.alt}}">{{/if}}
                         {{/with}}
                     </div>
+                    <div class="screen-reader-only expose-item-content-screen-reader" aria-live="polite" aria-atomic="true"></div>
                 </div>
             </div>
             {{/each}}


### PR DESCRIPTION
This PR contains fixes to the accessibility of expose. There is now an 'Expose content' button at the bottom of each panel and content is read out by the screen reader when it is exposed.

This has been tested with the NVDA screen reader on Chrome, Firefox & IE11.

We are aware of one minor issue: While previewing a course in firefox and IE11 the screen reader will continuously read out the alt text of the last card on the page. 

I am not sure where the best place is to put the 'Expose content' button text in the properties.schema. If you could please advise I will get this updated.

I am aware that currently, if the user does not specify an item title it is displayed as "?", which is not read out by screen readers. I'm not sure whether it would be sufficient to say this should be specified in order to make the course accessible or whether this needs an aria-label?